### PR TITLE
Minor fixes on maxRecordSize and flush success control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 - Some logs where referencing a wrong StreamName variable.
 - Added missing CHANGELOG version links.
+- fix maxRecordSize counting the return carriage concat by one byte.
+- fix flush counting totalBatchSize to check records not flushed.
+
+### Changed
+
+- Use metric Workers by label instead of stream name, just like other metrics.
+- Do not write newLine when ConcatRecords=false
+
+
 
 ## [2.0.0] - 2025-04-04
 

--- a/firehosepool/connect.go
+++ b/firehosepool/connect.go
@@ -99,5 +99,5 @@ func (srv *Server) clientsReset() {
 			srv.clients = append(srv.clients, NewClient(srv))
 		}
 	}
-	metricWorkers.WithLabelValues(srv.cfg.StreamName).Set(float64(len(srv.clients)))
+	metricWorkers.WithLabelValues(srv.cfg.Label).Set(float64(len(srv.clients)))
 }


### PR DESCRIPTION
- fix maxRecordSize counting the return carriage concat. Only write newLine when ConcatRecords=true.
- fix flush counting totalBatchSize to check records not flushed.
- use metric Workers by label instead of stream name.